### PR TITLE
[codex] Support arbitrary dotfiles install argv

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -11,6 +11,7 @@ TEMPLATE_ID="ghcr.io/technicalpickles/dotfiles-devcontainer/dotfiles:latest"
 INSTALL_ENV_VARS="${INSTALL_ENV_VARS:-}"
 DOTFILES_REPO="${DOTFILES_REPO:-https://github.com/technicalpickles/dotfiles.git}"
 DOTFILES_BRANCH="${DOTFILES_BRANCH:-main}"
+DOTFILES_INSTALL_ARGS_JSON="${DOTFILES_INSTALL_ARGS_JSON:-[]}"
 USER_SHELL="${USER_SHELL:-/usr/bin/fish}"
 USER_SHELL_NAME="${USER_SHELL_NAME:-}"
 PLATFORM_OVERRIDE="${PLATFORM_OVERRIDE:-}"
@@ -26,6 +27,32 @@ CLAUDE_CODE_FEATURE_REF="${CLAUDE_CODE_FEATURE_REF:-}"
 KEEP_VENDORED_FEATURES=false
 MODE=""
 SKIP_DIND=false
+
+normalize_install_args_json() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+try:
+    value = json.loads(sys.argv[1])
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"DOTFILES_INSTALL_ARGS_JSON must be valid JSON: {exc}")
+
+if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+    raise SystemExit("DOTFILES_INSTALL_ARGS_JSON must be a JSON array of strings")
+
+print(json.dumps(value, separators=(",", ":")))
+PY
+}
+
+encode_install_args_b64() {
+  python3 - "$1" <<'PY'
+import base64
+import sys
+
+print(base64.b64encode(sys.argv[1].encode()).decode())
+PY
+}
 
 # Normalize git URLs from SSH to HTTPS format
 normalize_git_url() {
@@ -421,6 +448,7 @@ ENVIRONMENT VARIABLES:
   INSTALL_ENV_VARS     Environment variables in KEY1=value1,KEY2=value2 format
   DOTFILES_REPO        Same as --repo
   DOTFILES_BRANCH      Same as --branch
+  DOTFILES_INSTALL_ARGS_JSON JSON array of argv tokens passed to dotfiles install.sh
   USER_SHELL           Same as --shell
   USER_SHELL_NAME      Override the terminal profile name (default: derived from USER_SHELL)
   PLATFORM_OVERRIDE    Same as --platform (forces platform flag in devcontainer build)
@@ -553,6 +581,9 @@ if [[ -z "$USER_SHELL_NAME" ]]; then
   USER_SHELL_NAME="$(basename "$USER_SHELL")"
 fi
 
+DOTFILES_INSTALL_ARGS_JSON="$(normalize_install_args_json "$DOTFILES_INSTALL_ARGS_JSON")"
+DOTFILES_INSTALL_ARGS_B64="$(encode_install_args_b64 "$DOTFILES_INSTALL_ARGS_JSON")"
+
 # Track if repo was explicitly set (for auto-detection)
 DOTFILES_REPO_EXPLICIT=false
 if [[ "$DOTFILES_REPO_WAS_FLAG" == "true" ]]; then
@@ -609,6 +640,7 @@ echo "  Mode: $MODE"
 echo "  Target directory: $TARGET_DIR"
 echo "  Dotfiles repo: $DOTFILES_REPO"
 echo "  Dotfiles branch: $DOTFILES_BRANCH"
+echo "  Dotfiles install argv: $DOTFILES_INSTALL_ARGS_JSON"
 echo "  User shell: $USER_SHELL (profile: $USER_SHELL_NAME)"
 echo "  Platform: ${PLATFORM_OVERRIDE:-auto-detect}"
 if [[ "$SKIP_DIND" == "true" ]]; then
@@ -723,7 +755,7 @@ if [[ "$IS_IN_REPO" == "true" ]]; then
 
    # Replace placeholders in devcontainer.json
    # Use Python for JSON-aware replacement to handle containerEnv as object, not string
-   python3 - .devcontainer/devcontainer.json "$DOTFILES_REPO" "$DOTFILES_BRANCH" "$USER_SHELL" "$USER_SHELL_NAME" "$CONTAINER_ENV_JSON" "$SKIP_DIND" <<'PY'
+   python3 - .devcontainer/devcontainer.json "$DOTFILES_REPO" "$DOTFILES_BRANCH" "$USER_SHELL" "$USER_SHELL_NAME" "$CONTAINER_ENV_JSON" "$SKIP_DIND" "$DOTFILES_INSTALL_ARGS_B64" <<'PY'
 import json, sys, re
 path = sys.argv[1]
 dotfiles_repo = sys.argv[2]
@@ -732,6 +764,7 @@ user_shell = sys.argv[4]
 user_shell_name = sys.argv[5]
 container_env_json = sys.argv[6]
 skip_dind = sys.argv[7] == "true"
+dotfiles_install_args_b64 = sys.argv[8]
 
 with open(path, 'r', encoding='utf-8') as f:
     raw = f.read()
@@ -747,6 +780,8 @@ if 'build' in obj and 'args' in obj['build']:
         args['DOTFILES_REPO'] = dotfiles_repo
     if 'DOTFILES_BRANCH' in args:
         args['DOTFILES_BRANCH'] = dotfiles_branch
+    if 'DOTFILES_INSTALL_ARGS_B64' in args:
+        args['DOTFILES_INSTALL_ARGS_B64'] = dotfiles_install_args_b64
     if 'USER_SHELL' in args:
         args['USER_SHELL'] = user_shell
 
@@ -783,6 +818,7 @@ PY
   # Replace placeholders in Dockerfile
   sed -i.bak "s|\${templateOption:dotfilesRepo}|$DOTFILES_REPO|g" .devcontainer/Dockerfile
   sed -i.bak "s|\${templateOption:dotfilesBranch}|$DOTFILES_BRANCH|g" .devcontainer/Dockerfile
+  sed -i.bak "s|\${templateOption:dotfilesInstallArgsB64}|$DOTFILES_INSTALL_ARGS_B64|g" .devcontainer/Dockerfile
   sed -i.bak "s|\${templateOption:userShell}|$USER_SHELL|g" .devcontainer/Dockerfile
   rm .devcontainer/Dockerfile.bak
 
@@ -806,6 +842,7 @@ PY
   # Replace placeholders in post-create.sh
   sed -i.bak "s|\${templateOption:dotfilesRepo}|$DOTFILES_REPO|g" .devcontainer/post-create.sh
   sed -i.bak "s|\${templateOption:dotfilesBranch}|$DOTFILES_BRANCH|g" .devcontainer/post-create.sh
+  sed -i.bak "s|\${templateOption:dotfilesInstallArgsB64}|$DOTFILES_INSTALL_ARGS_B64|g" .devcontainer/post-create.sh
   rm .devcontainer/post-create.sh.bak
 
   if [[ "$KEEP_VENDORED_FEATURES" == "true" ]]; then
@@ -872,6 +909,7 @@ else
     --template-id "$TEMPLATE_ID" \
     --template-args dotfilesRepo="$DOTFILES_REPO" \
     --template-args dotfilesBranch="$DOTFILES_BRANCH" \
+    --template-args dotfilesInstallArgsB64="$DOTFILES_INSTALL_ARGS_B64" \
     --template-args userShell="$USER_SHELL" \
     --template-args userShellName="$USER_SHELL_NAME" \
     $ENV_ARGS

--- a/bin/apply
+++ b/bin/apply
@@ -27,6 +27,7 @@ CLAUDE_CODE_FEATURE_REF="${CLAUDE_CODE_FEATURE_REF:-}"
 KEEP_VENDORED_FEATURES=false
 MODE=""
 SKIP_DIND=false
+INSTALL_ARGS=()
 
 normalize_install_args_json() {
   python3 - "$1" <<'PY'
@@ -51,6 +52,15 @@ import base64
 import sys
 
 print(base64.b64encode(sys.argv[1].encode()).decode())
+PY
+}
+
+install_args_json_from_array() {
+  python3 - "$@" <<'PY'
+import json
+import sys
+
+print(json.dumps(sys.argv[1:], separators=(",", ":")))
 PY
 }
 
@@ -436,6 +446,8 @@ ARGUMENTS:
 OPTIONS:
    --env KEY=VALUE    Environment variable to set before running dotfiles install.sh
                       Can be specified multiple times
+   --install-arg ARG  Argument token to pass to dotfiles install.sh
+                      Can be specified multiple times to build argv in order
    --repo URL         Dotfiles repository URL (default: auto-detected)
    --branch BRANCH    Dotfiles branch (default: main)
    --shell PATH       Login shell path for the vscode user (default: /usr/bin/fish)
@@ -476,6 +488,9 @@ EXAMPLES:
    # Custom dotfiles with env vars
    bin/apply ci-unpinned --repo https://github.com/myuser/dotfiles.git --env DOTFILES_ROLE=devcontainer .
 
+   # Pass unattended flags through to the dotfiles installer
+   bin/apply ci-unpinned --install-arg --yes .
+
    # Apply without Docker-in-Docker
    bin/apply ci-unpinned --no-dind /path/to/your/project
 
@@ -514,6 +529,10 @@ while [[ $# -gt 0 ]]; do
         echo "Error: --env requires KEY=VALUE format, got: $2" >&2
         exit 1
       fi
+      shift 2
+      ;;
+    --install-arg)
+      INSTALL_ARGS+=("$2")
       shift 2
       ;;
     --repo)
@@ -579,6 +598,10 @@ TARGET_DIR="$(cd "$TARGET_DIR" 2>/dev/null && pwd)" || {
 
 if [[ -z "$USER_SHELL_NAME" ]]; then
   USER_SHELL_NAME="$(basename "$USER_SHELL")"
+fi
+
+if [[ "${#INSTALL_ARGS[@]}" -gt 0 ]]; then
+  DOTFILES_INSTALL_ARGS_JSON="$(install_args_json_from_array "${INSTALL_ARGS[@]}")"
 fi
 
 DOTFILES_INSTALL_ARGS_JSON="$(normalize_install_args_json "$DOTFILES_INSTALL_ARGS_JSON")"

--- a/bin/test-bats
+++ b/bin/test-bats
@@ -11,4 +11,4 @@ if ! command -v bats >/dev/null; then
   exit 1
 fi
 
-exec bats test/apply.bats
+exec bats test/apply.bats test/setup-dotfiles.bats

--- a/docker/base/devcontainer-post-create
+++ b/docker/base/devcontainer-post-create
@@ -63,11 +63,15 @@ sync_dotfiles() {
   require_dotfiles_inputs
 
   local extra_env=()
+  local install_args=()
   for var in SKIP_MISE SKIP_FISH SKIP_GH SKIP_AWS; do
     if [[ -n "${!var:-}" ]]; then
       extra_env+=(--env "${var}=${!var}")
     fi
   done
+  if [[ -n "${DOTFILES_INSTALL_ARGS_B64:-}" ]]; then
+    install_args+=(--install-args-b64 "${DOTFILES_INSTALL_ARGS_B64}")
+  fi
 
   if [[ "${#extra_env[@]}" -gt 0 ]]; then
     printf "Forwarding dotfiles env:"
@@ -78,7 +82,7 @@ sync_dotfiles() {
   fi
 
   echo "Syncing dotfiles (${DOTFILES_REPO}@${DOTFILES_BRANCH})..."
-  setup-dotfiles --repo "${DOTFILES_REPO}" --branch "${DOTFILES_BRANCH}" --env "DOCKER_BUILD=false" "${extra_env[@]}"
+  setup-dotfiles --repo "${DOTFILES_REPO}" --branch "${DOTFILES_BRANCH}" --env "DOCKER_BUILD=false" "${extra_env[@]}" "${install_args[@]}"
   echo "Dotfiles sync complete"
 }
 

--- a/docker/base/setup-dotfiles
+++ b/docker/base/setup-dotfiles
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: setup-dotfiles --repo <url> --branch <name> [--dest /path/to/dir] [--env KEY=VALUE ...]
+Usage: setup-dotfiles --repo <url> --branch <name> [--dest /path/to/dir] [--env KEY=VALUE ...] [--install-arg ARG ...] [--install-args-json JSON] [--install-args-b64 B64]
 
 Clone (or refresh) a dotfiles repo and run its install.sh.
 Runs as the invoking user; does not change the default shell.
@@ -14,6 +14,31 @@ DEST="/home/vscode/.dotfiles"
 REPO=""
 BRANCH=""
 ENV_VARS=()
+INSTALL_ARGS=()
+
+append_install_args_json() {
+  local install_args_json="$1"
+  while IFS= read -r -d '' arg; do
+    INSTALL_ARGS+=("$arg")
+  done < <(
+    python3 - "$install_args_json" <<'PY'
+import json
+import sys
+
+try:
+    value = json.loads(sys.argv[1])
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"Error: --install-args-json must be valid JSON: {exc}")
+
+if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+    raise SystemExit("Error: --install-args-json must be a JSON array of strings")
+
+for item in value:
+    sys.stdout.buffer.write(item.encode("utf-8"))
+    sys.stdout.buffer.write(b"\0")
+PY
+  )
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -31,6 +56,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --env)
       ENV_VARS+=("$2")
+      shift 2
+      ;;
+    --install-arg)
+      INSTALL_ARGS+=("$2")
+      shift 2
+      ;;
+    --install-args-json)
+      append_install_args_json "$2"
+      shift 2
+      ;;
+    --install-args-b64)
+      append_install_args_json "$(python3 -c 'import base64, sys; print(base64.b64decode(sys.argv[1]).decode())' "$2")"
       shift 2
       ;;
     -h|--help)
@@ -73,5 +110,8 @@ if [[ ! -x "${DEST}/install.sh" ]]; then
   exit 1
 fi
 
-# Run install from inside the repo so relative paths resolve
-run_with_env bash -c "cd \"${DEST}\" && ./install.sh"
+# Run install from inside the repo so relative paths resolve.
+(
+  cd "${DEST}"
+  run_with_env ./install.sh "${INSTALL_ARGS[@]}"
+)

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 act = "latest"
 actionlint = "latest"
+bats = "latest"
 node = "lts"
 pkl = "latest"
 

--- a/src/dotfiles/.devcontainer/Dockerfile
+++ b/src/dotfiles/.devcontainer/Dockerfile
@@ -2,13 +2,18 @@ FROM ghcr.io/technicalpickles/dotfiles-devcontainer/base:latest
 
 ARG DOTFILES_REPO=${templateOption:dotfilesRepo}
 ARG DOTFILES_BRANCH=${templateOption:dotfilesBranch}
+ARG DOTFILES_INSTALL_ARGS_B64=${templateOption:dotfilesInstallArgsB64}
 ARG USER_SHELL=${templateOption:userShell}
 ARG DOCKER_BUILD=true
 
 USER vscode
 WORKDIR /home/vscode/.dotfiles
 
-RUN setup-dotfiles --repo "${DOTFILES_REPO}" --branch "${DOTFILES_BRANCH}" --env "DOCKER_BUILD=${DOCKER_BUILD}"
+RUN if [ -n "${DOTFILES_INSTALL_ARGS_B64}" ]; then \
+      setup-dotfiles --repo "${DOTFILES_REPO}" --branch "${DOTFILES_BRANCH}" --env "DOCKER_BUILD=${DOCKER_BUILD}" --install-args-b64 "${DOTFILES_INSTALL_ARGS_B64}"; \
+    else \
+      setup-dotfiles --repo "${DOTFILES_REPO}" --branch "${DOTFILES_BRANCH}" --env "DOCKER_BUILD=${DOCKER_BUILD}"; \
+    fi
 
 WORKDIR /home/vscode
 USER root

--- a/src/dotfiles/.devcontainer/devcontainer.json
+++ b/src/dotfiles/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     "args": {
       "DOTFILES_REPO": "${templateOption:dotfilesRepo}",
       "DOTFILES_BRANCH": "${templateOption:dotfilesBranch}",
+      "DOTFILES_INSTALL_ARGS_B64": "${templateOption:dotfilesInstallArgsB64}",
       "USER_SHELL": "${templateOption:userShell}",
       "DOCKER_BUILD": "true"
     }

--- a/src/dotfiles/.devcontainer/post-create.sh
+++ b/src/dotfiles/.devcontainer/post-create.sh
@@ -6,6 +6,8 @@ BASE_POST_CREATE="${BASE_POST_CREATE:-/usr/local/bin/devcontainer-post-create}"
 export DOTFILES_REPO="${templateOption:dotfilesRepo}"
 # shellcheck disable=SC2154 # templateOption placeholders replaced by apply
 export DOTFILES_BRANCH="${templateOption:dotfilesBranch}"
+# shellcheck disable=SC2154 # templateOption placeholders replaced by apply
+export DOTFILES_INSTALL_ARGS_B64="${templateOption:dotfilesInstallArgsB64}"
 export HOOK_ORDER="${HOOK_ORDER:-before}"
 
 DEFAULT_HOOK_PATH="/workspace/.devcontainer/hooks/post-create"
@@ -17,6 +19,7 @@ export HOOK_PATH="${HOOK_PATH:-${DEFAULT_HOOK_PATH}}"
 echo "Delegating post-create to base entrypoint..."
 echo "   DOTFILES_REPO=${DOTFILES_REPO}"
 echo "   DOTFILES_BRANCH=${DOTFILES_BRANCH}"
+echo "   DOTFILES_INSTALL_ARGS_B64=${DOTFILES_INSTALL_ARGS_B64}"
 echo "   HOOK_ORDER=${HOOK_ORDER}"
 echo "   HOOK_PATH=${HOOK_PATH}"
 

--- a/src/dotfiles/devcontainer-template.json
+++ b/src/dotfiles/devcontainer-template.json
@@ -15,6 +15,11 @@
       "description": "Dotfiles repository branch",
       "default": "main"
     },
+    "dotfilesInstallArgsB64": {
+      "type": "string",
+      "description": "Base64-encoded JSON array of argv tokens passed to install.sh during automated dotfiles setup",
+      "default": ""
+    },
     "userShell": {
       "type": "string",
       "description": "Login shell path for the vscode user",

--- a/test/apply.bats
+++ b/test/apply.bats
@@ -15,7 +15,7 @@ teardown() {
 }
 
 run_apply() {
-  local name="$1" repo="$2" branch="$3" shell="$4" profile="$5" platform="${6:-}" install_args_json="${7:-}"
+  local name="$1" repo="$2" branch="$3" shell="$4" profile="$5" platform="${6:-}" install_args_json="${7:-}" install_args_source="${8:-cli}"
   WORKDIR="$(mktemp -d "/tmp/devcontainer-${name}-XXXX")"
 
   local env_args=(
@@ -30,7 +30,7 @@ run_apply() {
   if [[ -n "$platform" ]]; then
     env_args+=("PLATFORM_OVERRIDE=$platform")
   fi
-  if [[ -n "$install_args_json" ]]; then
+  if [[ -n "$install_args_json" && "$install_args_source" == "env" ]]; then
     env_args+=("DOTFILES_INSTALL_ARGS_JSON=$install_args_json")
   fi
 
@@ -39,7 +39,20 @@ run_apply() {
     platform_args+=(--platform "$platform")
   fi
 
-  run env "${env_args[@]}" bash -x "$APPLY" ci-unpinned --repo "$repo" --branch "$branch" --shell "$shell" "${platform_args[@]}" "$WORKDIR"
+  local install_arg_flags=()
+  if [[ -n "$install_args_json" && "$install_args_source" == "cli" ]]; then
+    while IFS= read -r arg; do
+      install_arg_flags+=(--install-arg "$arg")
+    done < <(python3 - "$install_args_json" <<'PY'
+import json
+import sys
+for item in json.loads(sys.argv[1]):
+    print(item)
+PY
+    )
+  fi
+
+  run env "${env_args[@]}" bash -x "$APPLY" ci-unpinned --repo "$repo" --branch "$branch" --shell "$shell" "${platform_args[@]}" "${install_arg_flags[@]}" "$WORKDIR"
   if [[ "$status" -ne 0 ]]; then
     echo "apply failed (name=$name):"
     echo "$output"
@@ -198,13 +211,23 @@ assert_common_state() {
   local repo_url="file://${repo_dir}"
   local install_args_json='["--mode","fast","--yes"]'
 
-  run_apply install-argv "$repo_url" "main" "/usr/bin/fish" "" "" "$install_args_json"
+  run_apply install-argv "$repo_url" "main" "/usr/bin/fish" "" "" "$install_args_json" "env"
   assert_common_state "$repo_url" "main" "/usr/bin/fish" "fish" "$install_args_json"
 
   run rg -F -- '--install-arg "${DOTFILES_INSTALL_ARG}"' "$WORKDIR/.devcontainer/Dockerfile"
   [ "$status" -ne 0 ]
   run rg -F -- '--install-args-b64 "${DOTFILES_INSTALL_ARGS_B64}"' "$WORKDIR/.devcontainer/Dockerfile"
   [ "$status" -eq 0 ]
+}
+
+@test "apply accepts repeated install-arg flags on the CLI" {
+  local repo_dir
+  repo_dir="$(create_dotfiles_fixture_repo)"
+  local repo_url="file://${repo_dir}"
+  local install_args_json='["--mode","fast","--yes"]'
+
+  run_apply install-argv-cli "$repo_url" "main" "/usr/bin/fish" "" "" "$install_args_json" "cli"
+  assert_common_state "$repo_url" "main" "/usr/bin/fish" "fish" "$install_args_json"
 }
 
 @test "dind feature references ghcr and is not vendored" {

--- a/test/apply.bats
+++ b/test/apply.bats
@@ -15,7 +15,7 @@ teardown() {
 }
 
 run_apply() {
-  local name="$1" repo="$2" branch="$3" shell="$4" profile="$5" platform="${6:-}"
+  local name="$1" repo="$2" branch="$3" shell="$4" profile="$5" platform="${6:-}" install_args_json="${7:-}"
   WORKDIR="$(mktemp -d "/tmp/devcontainer-${name}-XXXX")"
 
   local env_args=(
@@ -29,6 +29,9 @@ run_apply() {
   fi
   if [[ -n "$platform" ]]; then
     env_args+=("PLATFORM_OVERRIDE=$platform")
+  fi
+  if [[ -n "$install_args_json" ]]; then
+    env_args+=("DOTFILES_INSTALL_ARGS_JSON=$install_args_json")
   fi
 
   local platform_args=()
@@ -92,7 +95,9 @@ NODE
 }
 
 assert_common_state() {
-  local repo="$1" branch="$2" shell="$3" profile="$4"
+  local repo="$1" branch="$2" shell="$3" profile="$4" install_args_json="${5:-[]}"
+  local install_args_b64
+  install_args_b64="$(python3 -c 'import base64, sys; print(base64.b64encode(sys.argv[1].encode()).decode())' "$install_args_json")"
 
   # No unresolved template placeholders in files we rewrite
   run rg -F '${templateOption' "$WORKDIR/.devcontainer/Dockerfile"
@@ -132,6 +137,12 @@ assert_common_state() {
     echo "shell mismatch: expected $shell got $shell_arg"
     return 1
   fi
+  local install_args_arg
+  install_args_arg="$(json_get "$dc_json" 'build.args.DOTFILES_INSTALL_ARGS_B64')"
+  if [[ "$install_args_arg" != "$install_args_b64" ]]; then
+    echo "install args mismatch: expected $install_args_b64 got $install_args_arg"
+    return 1
+  fi
   local profile_arg
   profile_arg="$(json_get "$dc_json" 'customizations.vscode.settings.terminal\.integrated\.defaultProfile\.linux')"
   if [[ "$profile_arg" != "$profile" ]]; then
@@ -158,6 +169,12 @@ assert_common_state() {
     echo "$output"
     return 1
   fi
+  run rg -F "$install_args_b64" "$WORKDIR/.devcontainer/post-create.sh"
+  if [[ "$status" -ne 0 ]]; then
+    echo "install args not found in post-create.sh"
+    echo "$output"
+    return 1
+  fi
   run rg -F "devcontainer-post-create" "$WORKDIR/.devcontainer/post-create.sh"
   if [[ "$status" -ne 0 ]]; then
     echo "base entrypoint delegation missing in post-create.sh"
@@ -173,6 +190,21 @@ assert_common_state() {
 
   run_apply default "$repo_url" "main" "/usr/bin/fish" ""
   assert_common_state "$repo_url" "main" "/usr/bin/fish" "fish"
+}
+
+@test "apply preserves arbitrary dotfiles install argv as JSON" {
+  local repo_dir
+  repo_dir="$(create_dotfiles_fixture_repo)"
+  local repo_url="file://${repo_dir}"
+  local install_args_json='["--mode","fast","--yes"]'
+
+  run_apply install-argv "$repo_url" "main" "/usr/bin/fish" "" "" "$install_args_json"
+  assert_common_state "$repo_url" "main" "/usr/bin/fish" "fish" "$install_args_json"
+
+  run rg -F -- '--install-arg "${DOTFILES_INSTALL_ARG}"' "$WORKDIR/.devcontainer/Dockerfile"
+  [ "$status" -ne 0 ]
+  run rg -F -- '--install-args-b64 "${DOTFILES_INSTALL_ARGS_B64}"' "$WORKDIR/.devcontainer/Dockerfile"
+  [ "$status" -eq 0 ]
 }
 
 @test "dind feature references ghcr and is not vendored" {

--- a/test/setup-dotfiles.bats
+++ b/test/setup-dotfiles.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  SETUP_DOTFILES="$REPO_ROOT/docker/base/setup-dotfiles"
+  mkdir -p "$REPO_ROOT/tmp"
+  TEST_TMPDIR="$(mktemp -d "${REPO_ROOT}/tmp/setup-dotfiles-XXXX")"
+}
+
+teardown() {
+  if [[ -n "${TEST_TMPDIR:-}" && -d "$TEST_TMPDIR" ]]; then
+    rm -rf "$TEST_TMPDIR"
+  fi
+}
+
+create_yes_required_repo() {
+  local repo_dir="$TEST_TMPDIR/yes-required-dotfiles"
+  mkdir -p "$repo_dir"
+
+  cat >"$repo_dir/install.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "--yes" ]]; then
+  echo "missing --yes" >&2
+  exit 42
+fi
+
+touch "${HOME}/.install-ran"
+EOF
+  chmod +x "$repo_dir/install.sh"
+
+  (
+    cd "$repo_dir" || exit 1
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git init -b main >/dev/null
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git config user.email "fixture@example.com"
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git config user.name "Fixture User"
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git add install.sh >/dev/null
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git commit -m "fixture" >/dev/null
+  )
+
+  printf '%s\n' "$repo_dir"
+}
+
+@test "setup-dotfiles passes explicit install args through to install.sh" {
+  local repo_dir
+  local home_dir="$TEST_TMPDIR/home"
+  repo_dir="$(create_yes_required_repo)"
+  mkdir -p "$home_dir"
+
+  run env HOME="$home_dir" bash "$SETUP_DOTFILES" \
+    --repo "file://${repo_dir}" \
+    --branch main \
+    --install-arg --yes \
+    --dest "$TEST_TMPDIR/dotfiles"
+
+  [ "$status" -eq 0 ]
+  [ -f "$home_dir/.install-ran" ]
+}
+
+@test "setup-dotfiles preserves argv boundaries across repeated install args" {
+  local repo_dir="$TEST_TMPDIR/multi-arg-dotfiles"
+  local home_dir="$TEST_TMPDIR/home"
+  mkdir -p "$repo_dir"
+  mkdir -p "$home_dir"
+
+  cat >"$repo_dir/install.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$#" > "${HOME}/argc"
+printf '%s\n' "$1" > "${HOME}/arg1"
+printf '%s\n' "$2" > "${HOME}/arg2"
+printf '%s\n' "$3" > "${HOME}/arg3"
+EOF
+  chmod +x "$repo_dir/install.sh"
+
+  (
+    cd "$repo_dir" || exit 1
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git init -b main >/dev/null
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git config user.email "fixture@example.com"
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git config user.name "Fixture User"
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git add install.sh >/dev/null
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git commit -m "fixture" >/dev/null
+  )
+
+  run env HOME="$home_dir" bash "$SETUP_DOTFILES" \
+    --repo "file://${repo_dir}" \
+    --branch main \
+    --install-arg --mode \
+    --install-arg fast \
+    --install-arg --yes \
+    --dest "$TEST_TMPDIR/dotfiles"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$home_dir/argc")" = "3" ]
+  [ "$(cat "$home_dir/arg1")" = "--mode" ]
+  [ "$(cat "$home_dir/arg2")" = "fast" ]
+  [ "$(cat "$home_dir/arg3")" = "--yes" ]
+}
+
+@test "setup-dotfiles parses install args from JSON" {
+  local repo_dir="$TEST_TMPDIR/json-arg-dotfiles"
+  local home_dir="$TEST_TMPDIR/home-json"
+  mkdir -p "$repo_dir"
+  mkdir -p "$home_dir"
+
+  cat >"$repo_dir/install.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$#" > "${HOME}/argc"
+printf '%s\n' "$1" > "${HOME}/arg1"
+printf '%s\n' "$2" > "${HOME}/arg2"
+printf '%s\n' "$3" > "${HOME}/arg3"
+EOF
+  chmod +x "$repo_dir/install.sh"
+
+  (
+    cd "$repo_dir" || exit 1
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git init -b main >/dev/null
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git config user.email "fixture@example.com"
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git config user.name "Fixture User"
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git add install.sh >/dev/null
+    GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null git commit -m "fixture" >/dev/null
+  )
+
+  run env HOME="$home_dir" bash "$SETUP_DOTFILES" \
+    --repo "file://${repo_dir}" \
+    --branch main \
+    --install-args-json '["--mode","fast","--yes"]' \
+    --dest "$TEST_TMPDIR/dotfiles-json"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$home_dir/argc")" = "3" ]
+  [ "$(cat "$home_dir/arg1")" = "--mode" ]
+  [ "$(cat "$home_dir/arg2")" = "fast" ]
+  [ "$(cat "$home_dir/arg3")" = "--yes" ]
+}


### PR DESCRIPTION
## What changed

This PR adds arbitrary dotfiles installer argv support end to end.

- `setup-dotfiles` now supports JSON/base64 transport for argv and still preserves repeated `--install-arg` tokens exactly.
- `bin/apply` now accepts repeated `--install-arg ARG` flags on the CLI and converts them into the internal JSON transport.
- The generated devcontainer config, Dockerfile, and post-create shim now carry install argv safely through build-time and post-create dotfiles setup.
- Tests were added for repeated argv preservation, JSON parsing, and the new `bin/apply --install-arg` CLI path.
- `mise.toml` now includes `bats` so the bats suite is available locally.

## Why

My dotfiles installer needs `--yes` for unattended devcontainer builds. The previous behavior only supported a single string-like value and did not provide a CLI surface on `bin/apply`, which made real non-interactive installer argv impossible to express cleanly.

## Impact

Consumers can now apply the template like this:

```bash
bin/apply local-dev --install-arg --yes /path/to/project
```

and have that argv preserved through:

- image build-time `setup-dotfiles`
- post-create `devcontainer-post-create`

## Validation

- `bash bin/test-bats`
- Applied the template to `../pickledpi` with `--install-arg --yes`
- Ran `devcontainer up --workspace-folder ../pickledpi`
- Verified the devcontainer built and post-create completed successfully with `DOTFILES_INSTALL_ARGS_B64` carrying `['--yes']`

## Notes

There is still a separate `local-dev` base-image rewrite issue where the generated Dockerfile continues to use `:latest` even after `bin/apply` detects `base:local`. For the `pickledpi` startup verification I worked around that by tagging the freshly built local base image as `:latest` before running `devcontainer up`.