### PR TITLE
[codex] Fix local-dev base image rewrite

### DIFF
--- a/bin/apply
+++ b/bin/apply
@@ -849,8 +849,8 @@ PY
   if [[ "$MODE" == "local-dev" ]]; then
     BASE_IMAGE_REPO="ghcr.io/technicalpickles/dotfiles-devcontainer/base"
     LOCAL_TAG="${BASE_IMAGE_REPO}:local"
-    # Rewrite FROM line to use :local tag
-    sed -i.bak "s|^FROM ${BASE_IMAGE_REPO}@sha256:[a-f0-9]*|FROM ${LOCAL_TAG}|" .devcontainer/Dockerfile
+    # Rewrite the template base image reference to the local tag.
+    sed -E -i.bak "s|^FROM ${BASE_IMAGE_REPO}([:@][^[:space:]]+)?$|FROM ${LOCAL_TAG}|" .devcontainer/Dockerfile
     rm .devcontainer/Dockerfile.bak
     # Check if local image exists
     if ! docker image inspect "${LOCAL_TAG}" >/dev/null 2>&1; then

--- a/test/apply.bats
+++ b/test/apply.bats
@@ -483,4 +483,11 @@ NODE
     echo "$output"
   fi
   [ "$status" -eq 0 ]
+
+  run rg -n '^FROM ghcr.io/technicalpickles/dotfiles-devcontainer/base:local$' "$WORKDIR/.devcontainer/Dockerfile"
+  if [[ "$status" -ne 0 ]]; then
+    echo "local-dev should rewrite Dockerfile base image to :local"
+    echo "$output"
+    return 1
+  fi
 }


### PR DESCRIPTION
## What changed

This PR fixes the `local-dev` base image rewrite in `bin/apply`.

- `bin/apply` now rewrites the generated Dockerfile base image to `ghcr.io/technicalpickles/dotfiles-devcontainer/base:local` in `local-dev` mode whether the template starts from `:latest` or a pinned digest.
- `test/apply.bats` now asserts that `local-dev` actually rewrites the Dockerfile `FROM` line to `:local`.

## Root cause

The rewrite logic only matched:

```text
FROM ghcr.io/technicalpickles/dotfiles-devcontainer/base@sha256:...
```

But the current template Dockerfile starts from:

```text
FROM ghcr.io/technicalpickles/dotfiles-devcontainer/base:latest
```

So `bin/apply local-dev` would claim it found `base:local` while leaving the generated Dockerfile on `:latest`.

## Validation

- `bash bin/test-bats`
- Applied from the bugfix worktree to `/Users/technicalpickles/github.com/technicalpickles/pickledpi` with:

```bash
bin/apply local-dev --install-arg --yes /Users/technicalpickles/github.com/technicalpickles/pickledpi
```

- Verified the generated `pickledpi/.devcontainer/Dockerfile` now starts with:

```Dockerfile
FROM ghcr.io/technicalpickles/dotfiles-devcontainer/base:local
```
